### PR TITLE
Replace `getInfo` with `getSpreadsheet`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var GoogleSpreadsheet = require("google-sheets-node-api");
 
 var mySheet = new GoogleSpreadsheet('<spreadsheet ID>');
 
-mySheet.useServiceAccountAuth(creds).then(mySheet.getInfo.bind(mySheet)).then(function(sheet_info ) {
+mySheet.useServiceAccountAuth(creds).then(mySheet.getSpreadsheet.bind(mySheet)).then(function(sheet_info) {
     console.log( sheet_info.title + ' is loaded' );
 
     var sheet1 = sheet_info.worksheets[0];


### PR DESCRIPTION
`getInfo` doesn't exist. I am using `getSpreadsheet` instead.

Instead of:
```
mySheet.useServiceAccountAuth(credentials).then(mySheet.getInfo.bind(mySheet)).then(function (info) {
                                                                       ^
TypeError: Cannot read property 'bind' of undefined
```

I use:
```
mySheet.useServiceAccountAuth(credentials).then(mySheet.getSpreadsheet.bind(mySheet)).then(function (info) {
```